### PR TITLE
Revert multi-vterm-buffer-list - changes let* to setq

### DIFF
--- a/multi-vterm.el
+++ b/multi-vterm.el
@@ -73,8 +73,8 @@ If nil, this defaults to the SHELL environment variable."
 (defun multi-vterm ()
   "Create new vterm buffer."
   (interactive)
-  (let* ((vterm-buffer (multi-vterm-get-buffer))
-         (multi-vterm-buffer-list (nconc multi-vterm-buffer-list (list vterm-buffer))))
+  (let* ((vterm-buffer (multi-vterm-get-buffer)))
+    (setq multi-vterm-buffer-list (nconc multi-vterm-buffer-list (list vterm-buffer)))
     (set-buffer vterm-buffer)
     (multi-vterm-internal)
     (switch-to-buffer vterm-buffer)))


### PR DESCRIPTION
Let declares local variables but multi-vterm-buffer-list is a global one in
order to track the current multi-vterm buffer list, so we want to modify it with
setq instead.
More information about local variables:
https://www.gnu.org/software/emacs/manual/html_node/elisp/Local-Variables.html