### PR TITLE
Refactoring to use more builtins (display-buffer)

### DIFF
--- a/multi-vterm.el
+++ b/multi-vterm.el
@@ -53,19 +53,6 @@ If nil, this defaults to the SHELL environment variable."
   "Match a multi-vterm buffer for `display-buffer-alist'."
   (string-prefix-p (concat "*" multi-vterm-buffer-name) buffer))
 
-(defun multi-vterm--update-display-alist (&rest _)
-  "Setter function for the display rules custom variables."
-  (customize-set-variable
-   'display-buffer-alist
-   '((multi-vterm--dedicated-term-matcher
-      (display-buffer-reuse-window display-buffer-in-side-window)
-      (dedicated . t))
-     (multi-vterm--term-matcher
-      (display-buffer-reuse-window display-buffer-pop-up-window)
-      (dedicated . t)
-      (inhibit-same-window . t)
-      (mode . vterm)))))
-
 (defcustom multi-vterm-dedicated-window-dimensions
   '(:target-width 70
     :target-height 30

--- a/multi-vterm.el
+++ b/multi-vterm.el
@@ -73,8 +73,7 @@ If nil, this defaults to the SHELL environment variable."
              (window-width . ,(plist-get new-value :target-width))))))
   :group 'multi-vterm)
 
-(defcustom multi-vterm-dedicated-window-side
-  'bottom
+(defcustom multi-vterm-dedicated-window-side 'bottom
   "The side of the dedicated window"
   :type '(choice (const :tag "Bottom" bottom)
                  (const :tag "Top" top)
@@ -86,7 +85,7 @@ If nil, this defaults to the SHELL environment variable."
           `((multi-vterm--dedicated-term-matcher
              (display-buffer-in-side-window)
              (dedicated . t)
-             (side . ,new-value )))))
+             (side . ,new-value)))))
   :group 'multi-vterm)
 
 (defcustom multi-vterm-window-dimensions

--- a/multi-vterm.el
+++ b/multi-vterm.el
@@ -47,11 +47,11 @@ If nil, this defaults to the SHELL environment variable."
 
 (defun multi-vterm--dedicated-term-matcher (buffer _action)
   "Match the dedicated multi-vterm buffer for `display-buffer-alist'."
-  (string-equal (multi-vterm--dedicated-get-buffer-name) buffer))
+  (string-equal (multi-vterm--dedicated-get-buffer-name) (buffer-name buffer)))
 
 (defun multi-vterm--term-matcher (buffer _action)
   "Match a multi-vterm buffer for `display-buffer-alist'."
-  (string-prefix-p (concat "*" multi-vterm-buffer-name) buffer))
+  (string-prefix-p (concat "*" multi-vterm-buffer-name) (buffer-name buffer)))
 
 (defcustom multi-vterm-dedicated-window-dimensions
   '(:target-width 70

--- a/multi-vterm.el
+++ b/multi-vterm.el
@@ -145,15 +145,18 @@ If nil, this defaults to the SHELL environment variable."
 (defun multi-vterm-project ()
   "Create new project vterm buffer."
   (interactive)
-  ;; TODO: simplify this function to make it a toggle as well
-  (if (multi-vterm-project-root)
+  (if-let ((project-name (multi-vterm-project-root)))
       (if (buffer-live-p (get-buffer (multi-vterm-project-get-buffer-name)))
           (if (string-equal (buffer-name (current-buffer)) (multi-vterm-project-get-buffer-name))
-              (delete-window (selected-window))
-            (pop-to-buffer (multi-vterm-project-get-buffer-name)))
+              (progn
+                (delete-window (selected-window))
+                (message "Deleted terminal window for %s" project-name))
+            (pop-to-buffer (multi-vterm-project-get-buffer-name))
+            (message "Switched terminal window for %s" project-name))
         (let* ((vterm-buffer (multi-vterm-get-buffer-create 'project))
                (multi-vterm-buffer-list (nconc multi-vterm-buffer-list (list vterm-buffer))))
-          (pop-to-buffer vterm-buffer)))
+          (pop-to-buffer vterm-buffer)
+          (message "Added terminal window for %s" project-name)))
     (user-error "This file is not in a project")))
 
 ;;;###autoload
@@ -331,8 +334,12 @@ Option OFFSET for skip OFFSET number term buffer."
           (let ((target-index (if (eq direction 'NEXT)
                                   (mod (+ my-index offset) buffer-list-len)
                                 (mod (- my-index offset) buffer-list-len))))
-            (pop-to-buffer (nth target-index multi-vterm-buffer-list)))
-        (pop-to-buffer (car multi-vterm-buffer-list))))))
+            (pop-to-buffer (nth target-index multi-vterm-buffer-list))
+            (message "Terminal %s / %s" (1+ target-index) buffer-list-len)
+            t)
+        (pop-to-buffer (car multi-vterm-buffer-list))
+        (message "Terminal 1 / %s" buffer-list-len)
+        t))))
 
 
 (provide 'multi-vterm)

--- a/multi-vterm.el
+++ b/multi-vterm.el
@@ -36,7 +36,7 @@
 
 (defcustom multi-vterm-program nil
   "The shell program run by vterm.
-If nil, this defaults to the SHELL environment variable."
+ If nil, this defaults to the SHELL environment variable."
   :type 'string
   :group 'multi-vterm)
 
@@ -47,11 +47,11 @@ If nil, this defaults to the SHELL environment variable."
 
 (defun multi-vterm--dedicated-term-matcher (buffer _action)
   "Match the dedicated multi-vterm buffer for `display-buffer-alist'."
-  (string-equal (multi-vterm--dedicated-get-buffer-name) (buffer-name buffer)))
+  (string-equal (multi-vterm--dedicated-get-buffer-name) (if (bufferp buffer) (buffer-name buffer) buffer)))
 
 (defun multi-vterm--term-matcher (buffer _action)
   "Match a multi-vterm buffer for `display-buffer-alist'."
-  (string-prefix-p (concat "*" multi-vterm-buffer-name) (buffer-name buffer)))
+  (string-prefix-p (concat "*" multi-vterm-buffer-name) (if (bufferp buffer) (buffer-name buffer) buffer)))
 
 (defcustom multi-vterm-dedicated-window-dimensions
   '(:target-width 70
@@ -181,7 +181,7 @@ If nil, this defaults to the SHELL environment variable."
 
 (defun multi-vterm-get-buffer-create (&optional dedicated-window)
   "Get vterm buffer based on DEDICATED-WINDOW, creating it if necessary.
-Optional argument DEDICATED-WINDOW: There are three types of DEDICATED-WINDOW: dedicated, project, default."
+ Optional argument DEDICATED-WINDOW: There are three types of DEDICATED-WINDOW: dedicated, project, default."
   (with-temp-buffer
     (let ((index 1)
           vterm-name)
@@ -242,21 +242,21 @@ Optional argument DEDICATED-WINDOW: There are three types of DEDICATED-WINDOW: d
 
 (defun multi-vterm-next (&optional offset)
   "Go to the next term buffer.
-If OFFSET is `non-nil', will goto next term buffer with OFFSET."
+ If OFFSET is `non-nil', will goto next term buffer with OFFSET."
   (interactive "P")
   (multi-vterm--switch 'NEXT (or offset 1)))
 
 (defun multi-vterm-prev (&optional offset)
   "Go to the previous term buffer.
-If OFFSET is `non-nil', will goto next term buffer with OFFSET."
+ If OFFSET is `non-nil', will goto next term buffer with OFFSET."
   (interactive "P")
   (multi-vterm--switch 'PREVIOUS (or offset 1)))
 
 (defun multi-vterm--switch (direction offset)
   "Internal `multi-vterm' buffers switch function.
-If DIRECTION is `NEXT', switch to the next term.
-If DIRECTION `PREVIOUS', switch to the previous term.
-Option OFFSET for skip OFFSET number term buffer."
+ If DIRECTION is `NEXT', switch to the next term.
+ If DIRECTION `PREVIOUS', switch to the previous term.
+ Option OFFSET for skip OFFSET number term buffer."
   (unless (multi-vterm--switch-internal direction offset)
     (multi-vterm)))
 
@@ -304,14 +304,14 @@ Option OFFSET for skip OFFSET number term buffer."
 
 (defun multi-vterm--buffer-exist-p (buffer)
   "Return non-nil if BUFFER exist.
-Otherwise return nil."
+ Otherwise return nil."
   (and buffer (buffer-live-p buffer)))
 
 (defun multi-vterm--switch-internal (direction offset)
   "Internal `multi-vterm' buffers switch function.
-If DIRECTION is `NEXT', switch to the next term.
-If DIRECTION `PREVIOUS', switch to the previous term.
-Option OFFSET for skip OFFSET number term buffer."
+ If DIRECTION is `NEXT', switch to the next term.
+ If DIRECTION `PREVIOUS', switch to the previous term.
+ Option OFFSET for skip OFFSET number term buffer."
   (when multi-vterm-buffer-list
     (let ((buffer-list-len (length multi-vterm-buffer-list))
           (my-index (cl-position (current-buffer) multi-vterm-buffer-list)))

--- a/multi-vterm.el
+++ b/multi-vterm.el
@@ -101,9 +101,8 @@ If nil, this defaults to the SHELL environment variable."
          (customize-set-variable
           'display-buffer-alist
           `((multi-vterm--term-matcher
-             (display-buffer-reuse-window display-buffer-pop-up-window)
+             (display-buffer-reuse-window display-buffer-pop-up-window display-buffer-use-some-window display-buffer-use-some-frame display-buffer-pop-up-frame)
              (dedicated . t)
-             (inhibit-same-window . t)
              (mode . vterm)
              (window-min-height . ,(plist-get new-value :min-height))
              (window-height . ,(plist-get new-value :target-height))


### PR DESCRIPTION
Hello,

Thanks for the package. When I started using it I noticed that the windows from the vterm buffers didn't respect the customizations that I wanted to put in `display-buffer-alist`, so I made a few changes. I don't know if you will want to merge them (there are a lot), and I didn't test completely the changes:

- Use `pop-to-buffer` instead of manual window manipulations and switch
- Change the `defcustom` to mimic parameters from `display-buffer-alist` to control window positions
- Simplify the toggle functions to use more extensively `get-buffer` and `get-buffer-window`
- Use the `--` convention for internal functions
- Rename `multi-vterm-get-buffer` to show that it creates a buffer on miss, just like the difference between `get-buffer` and `get-buffer-create`

There are probably a few other changes. I set the PR as draft because I would like to test those changes on my setup for a few weeks before, but I'll take all feedback (even if it is "I won't merge it")